### PR TITLE
Invalid timestamp for persistent notification (Closes #123)

### DIFF
--- a/src/com/xabber/android/data/notification/NotificationManager.java
+++ b/src/com/xabber/android/data/notification/NotificationManager.java
@@ -394,7 +394,7 @@ public class NotificationManager implements OnInitializedListener,
 			if (Application.SDK_INT >= 14 && SettingsManager.eventsPersistent()) {
 				// Ongoing icons are in the left side, so hide this one.
 				notification.icon = R.drawable.ic_placeholder;
-				notification.when = Long.MIN_VALUE;
+				notification.when = 0;
 			} else {
 				// Ongoing icons are in the right side, so show this one.
 				updateNotification(notification, ticker);
@@ -450,11 +450,10 @@ public class NotificationManager implements OnInitializedListener,
 				updateNotification(persistentNotification, ticker);
 			} else {
 				persistentNotification.icon = R.drawable.ic_placeholder;
-				persistentNotification.when = Application.SDK_INT >= 9 ? -Long.MAX_VALUE
-						: Long.MAX_VALUE;
+				persistentNotification.when = 0;
 			}
 		}
-
+		
 		if (SettingsManager.eventsPersistent()) {
 			notify(PERSISTENT_NOTIFICATION_ID, persistentNotification);
 		} else {


### PR DESCRIPTION
I've found out that setting `persistentNotification.when = -Long.MAX_VALUE` makes date TextView look like `28.11.17`. I've just tested [the code](https://github.com/android/platform_frameworks_base/blob/master/core/java/android/widget/DateTimeView.java) that renders it. So I've changed the constant to 0, it works on API level 10 (hides the timestamp), maybe needs more testing though. Please refer to this [question](http://stackoverflow.com/questions/5757997/hide-time-in-android-notification-without-using-custom-layout) for more info.
