### PR TITLE
Update chat_viewer.xml

### DIFF
--- a/res/values/chat_viewer.xml
+++ b/res/values/chat_viewer.xml
@@ -23,7 +23,7 @@
     <!-- http://dl.dropbox.com/u/1029995/com.xabber.android/chat_viewer_option_menu_extra.png -->
     <string name="clear_message">Clear text</string>
     <!-- http://dl.dropbox.com/u/1029995/com.xabber.android/chat_viewer_contact_is_offline.png -->
-    <string name="contact_is_offline">The recipient is offline. Messages you send will be delivered when he comes back online.</string>
+    <string name="contact_is_offline">The recipient is offline. Messages you send will be delivered when they come back online.</string>
     <!-- http://dl.dropbox.com/u/1029995/com.xabber.android/contact_list_error.png -->
     <string name="ENTRY_IS_NOT_AVAILABLE">Contact is not available</string>
     <!-- http://dl.dropbox.com/u/1029995/com.xabber.android/contact_list_error.png -->


### PR DESCRIPTION
As a recent convert to Xabber on Android, only one small thing annoyed me about the interface - when I'm chatting with a female user, and she goes offline, the app tells me that messages I send "will be delivered when *he* comes back online". 

Since there's no generally reliable way to tell the gender of a contact, it would be better to use the gender-neutral form "when they come back online" in this message.

(An alternative would be to say "N is offline, messages will be delivered when N comes back online", where N is the user's name. But that would require changing more code ;-))

Cheers!