### PR TITLE
set resource to null when close an active chat.

### DIFF
--- a/src/com/xabber/android/data/message/MessageManager.java
+++ b/src/com/xabber/android/data/message/MessageManager.java
@@ -247,6 +247,8 @@ public class MessageManager implements OnLoadListener, OnPacketListener,
 		AbstractChat chat = getChat(account, user);
 		if (chat == null)
 			return;
+		if (chat instanceof RegularChat)
+			((RegularChat) chat).clearResource();
 		chat.closeChat();
 	}
 

--- a/src/com/xabber/android/data/message/RegularChat.java
+++ b/src/com/xabber/android/data/message/RegularChat.java
@@ -57,6 +57,10 @@ public class RegularChat extends AbstractChat {
 		return resource;
 	}
 
+	public void clearResource() {
+		resource = null;
+	}
+
 	@Override
 	public String getTo() {
 		if (resource == null)


### PR DESCRIPTION
I think it would be useful to set the resource of an closed chat explicitly to null. 
So when you send a new message to this contact and create a new active chat the message goes to barejid instead to the saved jid.
