### PR TITLE
Get code to compile for API level 11

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -234,7 +234,7 @@
         <receiver android:name="com.xabber.android.receiver.GoXaReceiver" />
         <receiver android:name="com.xabber.android.receiver.ComposingPausedReceiver" />
     </application>
-    <uses-sdk android:minSdkVersion="3" android:targetSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="3" android:targetSdkVersion="11" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false" />
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />

--- a/project.properties
+++ b/project.properties
@@ -10,4 +10,4 @@
 # Indicates whether an apk should be generated for each density.
 split.density=false
 # Project target.
-target=android-9
+target=android-11

--- a/src/com/xabber/android/service/XabberService.java
+++ b/src/com/xabber/android/service/XabberService.java
@@ -38,6 +38,7 @@ public class XabberService extends Service {
 
 	private Method startForeground;
 	private Method stopForeground;
+	private Method setForeground;
 
 	private static XabberService instance;
 
@@ -59,6 +60,14 @@ public class XabberService extends Service {
 					new Class[] { boolean.class });
 		} catch (NoSuchMethodException e) {
 			startForeground = stopForeground = null;
+		}
+
+		// Try to get methods supported in API Level <5
+		try {
+			setForeground = getClass().getMethod("setForeground",
+					new Class[] { int.class, Notification.class });
+		} catch (NoSuchMethodException e) {
+			setForeground = null;
 		}
 
 		changeForeground();
@@ -111,7 +120,15 @@ public class XabberService extends Service {
 				LogManager.w(this, "Unable to invoke startForeground" + e);
 			}
 		} else {
-			setForeground(true);
+			try {
+				setForeground.invoke(this, new Object[] { Boolean.TRUE });
+			} catch (InvocationTargetException e) {
+				// Should not happen.
+				LogManager.w(this, "Unable to invoke setForeground" + e);
+			} catch (IllegalAccessException e) {
+				// Should not happen.
+				LogManager.w(this, "Unable to invoke setForeground" + e);
+			}
 			try {
 				((android.app.NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
 						.notify(NotificationManager.PERSISTENT_NOTIFICATION_ID,
@@ -138,7 +155,15 @@ public class XabberService extends Service {
 				LogManager.w(this, "Unable to invoke stopForeground" + e);
 			}
 		} else {
-			setForeground(false);
+			try {
+				setForeground.invoke(this, new Object[] { Boolean.FALSE });
+			} catch (InvocationTargetException e) {
+				// Should not happen.
+				LogManager.w(this, "Unable to invoke setForeground" + e);
+			} catch (IllegalAccessException e) {
+				// Should not happen.
+				LogManager.w(this, "Unable to invoke setForeground" + e);
+			}
 		}
 	}
 

--- a/src/com/xabber/android/utils/DummyCursor.java
+++ b/src/com/xabber/android/utils/DummyCursor.java
@@ -209,4 +209,9 @@ public class DummyCursor implements Cursor {
 		return null;
 	}
 
+  @Override
+  public int getType (int columnIndex) {
+    return 0;
+  }
+
 }


### PR DESCRIPTION
* setForeground has been removed since API 11, hence do for it the same workaround that you've done for {start,stop}Foreground
* Add override for Cursor#getType method 