### PR TITLE
otr4j also uses gradle now

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,5 @@
 apply plugin: 'com.android.application'
 
-repositories {
-  mavenCentral()
-  mavenLocal()
-}
-
 android {
     compileSdkVersion 21
     buildToolsVersion "21.1.2"
@@ -15,12 +10,6 @@ android {
         targetSdkVersion 21
         versionCode 116
         versionName '0.10.19'
-    }
-
-    sourceSets {
-        main {
-            java.srcDirs = ['src/main/java', 'otr4j/src/main/java']
-        }
     }
 
     buildTypes {
@@ -38,5 +27,5 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:support-v13:21.0.3'
-    compile 'org.bouncycastle:bcprov-jdk15on:1.49'
+    compile project('otr4j')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':app'
+include ':app:otr4j'


### PR DESCRIPTION
otr4j also uses gradle now, so xabber's build.gradle should just compile otr4j as a subproject.