### PR TITLE
Add dark theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -324,6 +324,15 @@
             />
 
         <activity
+            android:name="com.xabber.android.ui.preferences.ThemeSettings"
+            android:parentActivityName="com.xabber.android.ui.preferences.PreferenceEditor">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.xabber.android.ui.preferences.PreferenceEditor" />
+        </activity>
+
+        <activity
             android:name="com.xabber.android.ui.preferences.ContactListSettings"
             android:parentActivityName="com.xabber.android.ui.preferences.PreferenceEditor">
             <!-- Parent activity meta-data to support 4.0 and lower -->

--- a/app/src/main/java/com/xabber/android/data/ActivityManager.java
+++ b/app/src/main/java/com/xabber/android/data/ActivityManager.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 import com.xabber.android.R;
 import com.xabber.android.ui.ContactList;
 import com.xabber.android.ui.LoadActivity;
+import com.xabber.android.data.SettingsManager;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -119,7 +120,11 @@ public class ActivityManager implements OnUnloadListener {
      * @param activity
      */
     private void applyTheme(Activity activity) {
-        activity.setTheme(R.style.Theme);
+        SettingsManager.InterfaceTheme theme = SettingsManager.interfaceTheme();
+        if(theme.equals(SettingsManager.InterfaceTheme.dark))
+          activity.setTheme(R.style.DarkTheme);
+        else
+          activity.setTheme(R.style.Theme);
     }
 
     /**
@@ -132,6 +137,8 @@ public class ActivityManager implements OnUnloadListener {
     public void onCreate(Activity activity) {
         if (LOG)
             LogManager.i(activity, "onCreate: " + activity.getIntent());
+        if(!activity.getClass().getSimpleName().equals("AboutViewer"))
+            applyTheme(activity);
         if (application.isClosing() && !(activity instanceof LoadActivity)) {
             activity.startActivity(LoadActivity.createIntent(activity));
             activity.finish();

--- a/app/src/main/java/com/xabber/android/ui/adapter/ChatMessageAdapter.java
+++ b/app/src/main/java/com/xabber/android/ui/adapter/ChatMessageAdapter.java
@@ -204,6 +204,7 @@ public class ChatMessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
         message.messageText.setText(messageItem.getSpannable());
 
         message.messageBalloon.getBackground().setLevel(AccountManager.getInstance().getColorLevel(account));
+        message.messageBalloon.getBackground().setAlpha(150);
 
         String time = StringUtils.getSmartTimeText(context, messageItem.getTimestamp());
 

--- a/app/src/main/java/com/xabber/android/ui/adapter/ContactItemInflater.java
+++ b/app/src/main/java/com/xabber/android/ui/adapter/ContactItemInflater.java
@@ -1,5 +1,7 @@
 package com.xabber.android.ui.adapter;
 
+import android.content.res.TypedArray;
+import android.util.TypedValue;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
@@ -89,7 +91,7 @@ public class ContactItemInflater {
 
             statusText = chat.getLastText().trim();
 
-            view.setBackgroundColor(context.getResources().getColor(R.color.contact_list_active_chat_background));
+            setBackgroundColor(view, R.attr.contact_list_active_chat_background);
 
             if (!statusText.isEmpty()) {
 
@@ -111,7 +113,7 @@ public class ContactItemInflater {
             }
         } else {
             statusText = contact.getStatusText().trim();
-            view.setBackgroundColor(context.getResources().getColor(R.color.contact_list_contact_background));
+            setBackgroundColor(view, R.attr.contact_list_contact_background);
             viewHolder.largeClientIcon.setVisibility(View.VISIBLE);
             viewHolder.largeClientIcon.setImageLevel(clientSoftware.ordinal());
         }
@@ -125,6 +127,13 @@ public class ContactItemInflater {
 
         viewHolder.statusIcon.setImageLevel(contact.getStatusMode().getStatusLevel());
         return view;
+    }
+
+    private void setBackgroundColor(View view, int colorAttribute) {
+        TypedArray a = context.obtainStyledAttributes(new int[] {colorAttribute});
+        int attributeResourceId = a.getResourceId(0, 0);
+        a.recycle();
+        view.setBackgroundColor(context.getResources().getColor(attributeResourceId));
     }
 
     private void onAvatarClick(AbstractContact contact) {

--- a/app/src/main/java/com/xabber/android/ui/adapter/GroupedContactAdapter.java
+++ b/app/src/main/java/com/xabber/android/ui/adapter/GroupedContactAdapter.java
@@ -107,7 +107,7 @@ public abstract class GroupedContactAdapter extends BaseAdapter implements Updat
 
 
         accountGroupColors = resources.getIntArray(R.array.account_200);
-        accountSubgroupColors = resources.getIntArray(R.array.account_50);
+        accountSubgroupColors = resources.getIntArray(R.array.account_background);
         activeChatsColor = resources.getColor(R.color.contact_list_active_chats_group_background);
 
         contactItemInflater = new ContactItemInflater(activity);

--- a/app/src/main/java/com/xabber/android/ui/preferences/ThemeSettings.java
+++ b/app/src/main/java/com/xabber/android/ui/preferences/ThemeSettings.java
@@ -1,0 +1,44 @@
+package com.xabber.android.ui.preferences;
+
+import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
+
+import com.xabber.android.ui.helper.BarPainter;
+import com.xabber.android.data.ActivityManager;
+import com.xabber.android.ui.ContactList;
+import com.xabber.android.ui.helper.ManagedActivity;
+import com.xabber.android.ui.helper.PreferenceSummaryHelper;
+import com.xabber.android.R;
+
+public class ThemeSettings extends ManagedActivity
+        implements ThemeSettingsFragment.OnThemeSettingsFragmentInteractionListener {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (isFinishing())
+            return;
+
+        setContentView(R.layout.activity_with_toolbar_and_container);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar_default);
+        setSupportActionBar(toolbar);
+
+        BarPainter barPainter = new BarPainter(this, toolbar);
+        barPainter.setDefaultColor();
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+
+        setTitle(PreferenceSummaryHelper.getPreferenceTitle(getString(R.string.preference_interface)));
+
+        if (savedInstanceState == null) {
+            getFragmentManager().beginTransaction()
+                    .add(R.id.fragment_container, new ThemeSettingsFragment()).commit();
+        }
+    }
+
+    @Override
+    public void onThemeChanged() {
+        ActivityManager.getInstance().clearStack(true);
+        startActivity(ContactList.createIntent(this));
+    }
+}

--- a/app/src/main/java/com/xabber/android/ui/preferences/ThemeSettingsFragment.java
+++ b/app/src/main/java/com/xabber/android/ui/preferences/ThemeSettingsFragment.java
@@ -1,0 +1,67 @@
+package com.xabber.android.ui.preferences;
+
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+
+import com.xabber.android.ui.helper.PreferenceSummaryHelper;
+import com.xabber.android.R;
+
+public class ThemeSettingsFragment extends android.preference.PreferenceFragment
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private OnThemeSettingsFragmentInteractionListener mListener;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.preference_theme);
+
+        PreferenceSummaryHelper.updateSummary(getPreferenceScreen());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        PreferenceManager.getDefaultSharedPreferences(getActivity())
+                .registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        PreferenceManager.getDefaultSharedPreferences(getActivity())
+                .unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key.equals(getString(R.string.interface_theme_key))) {
+            mListener.onThemeChanged();
+        }
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        try {
+            mListener = (OnThemeSettingsFragmentInteractionListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString()
+                    + " must implement OnThemeSettingsFragmentInteractionListener");
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mListener = null;
+    }
+
+    public interface OnThemeSettingsFragmentInteractionListener {
+        public void onThemeChanged();
+    }
+}

--- a/app/src/main/res/layout/chat_viewer_fragment.xml
+++ b/app/src/main/res/layout/chat_viewer_fragment.xml
@@ -28,7 +28,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="8dp"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:popupTheme="?attr/toolbar_popup_theme"
         >
 
         <include
@@ -57,7 +57,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:background="@color/white"
+        android:background="?attr/input_layout_background"
         android:elevation="8dp"
         android:orientation="horizontal"
         >

--- a/app/src/main/res/layout/contact_list.xml
+++ b/app/src/main/res/layout/contact_list.xml
@@ -32,7 +32,7 @@
             android:background="?attr/colorPrimary"
             android:elevation="4dp"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            app:popupTheme="?attr/toolbar_popup_theme"
             app:titleTextAppearance="@style/ToolbarTitle" />
 
         <!-- Main layout -->

--- a/app/src/main/res/layout/contact_list_drawer.xml
+++ b/app/src/main/res/layout/contact_list_drawer.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/background_light"
+    android:background="?attr/drawer_background"
     android:clickable="true"
     android:orientation="vertical">
 

--- a/app/src/main/res/layout/contact_list_fragment.xml
+++ b/app/src/main/res/layout/contact_list_fragment.xml
@@ -24,7 +24,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:drawSelectorOnTop="true"
-        android:background="@color/contact_list_background"
+        android:background="?attr/contact_list_background"
         android:divider="@null"
         android:dividerHeight="0dp"
         />

--- a/app/src/main/res/layout/expandable_contact_title_activity.xml
+++ b/app/src/main/res/layout/expandable_contact_title_activity.xml
@@ -35,7 +35,7 @@
         android:layout_height="?attr/actionBarSize"
         app:titleTextAppearance="@style/ToolbarTitle"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:popupTheme="?attr/toolbar_popup_theme"
         android:elevation="8dp"
         />
 

--- a/app/src/main/res/layout/toolbar_default.xml
+++ b/app/src/main/res/layout/toolbar_default.xml
@@ -8,7 +8,7 @@
 
     app:titleTextAppearance="@style/ToolbarTitle"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:popupTheme="?attr/toolbar_popup_theme"
     android:background="?attr/colorPrimary"
     android:elevation="8dp"
     />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2013, Redsolution LTD. All rights reserved.
+
+     This file is part of Xabber project; you can redistribute it and/or
+     modify it under the terms of the GNU General Public License, Version 3.
+
+     Xabber is distributed in the hope that it will be useful, but
+     WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License,
+     along with this program. If not, see http://www.gnu.org/licenses/.
+-->
+<resources>
+    <declare-styleable name="ContactList">
+        <attr name="input_layout_background" format="reference" />
+        <attr name="toolbar_popup_theme" format="reference" />
+        <attr name="drawer_background" format="reference" />
+        <attr name="contact_list_active_chat_background" format="reference" />
+        <attr name="contact_list_contact_background" format="reference" />
+        <attr name="contact_list_background" format="reference" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -84,7 +84,6 @@
 
     <color name="account_disabled">@color/black_dividers</color>
 
-    <color name="contact_list_background">@color/grey_400</color>
     <color name="contact_list_active_chats_group_background">@color/grey_200</color>
     <color name="contact_list_active_chat_background">@color/grey_50</color>
     <color name="contact_list_contact_background">@color/grey_300</color>

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -20,6 +20,30 @@
 
         <!--for text selection toolbar to be above usual toolbar -->
         <item name="windowActionModeOverlay">true</item>
+
+        <item name="input_layout_background">@color/white</item>
+        <item name="toolbar_popup_theme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="drawer_background">@android:color/background_light</item>
+        <item name="contact_list_active_chat_background">@color/grey_50</item>
+        <item name="contact_list_contact_background">@color/grey_300</item>
+        <item name="contact_list_background">@color/grey_400</item>
+    </style>
+    <style name="DarkTheme" parent="Theme.AppCompat">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+
+        <!--for text selection toolbar to be above usual toolbar -->
+        <item name="windowActionModeOverlay">true</item>
+
+        <!-- for hardware button menu -->
+        <item name="panelBackground">?attr/colorPrimary</item>
+
+        <item name="input_layout_background">@color/black</item>
+        <item name="toolbar_popup_theme">@style/ThemeOverlay.AppCompat</item>
+        <item name="drawer_background">@android:color/background_dark</item>
+        <item name="contact_list_active_chat_background">@color/grey_700</item>
+        <item name="contact_list_contact_background">@android:color/transparent</item>
+        <item name="contact_list_background">@android:color/transparent</item>
     </style>
 
     <style name="ThemeDark" parent="Base.ThemeDark"></style>

--- a/app/src/main/res/xml/preference_editor.xml
+++ b/app/src/main/res/xml/preference_editor.xml
@@ -20,6 +20,13 @@
     </Preference>
 
     <Preference
+        android:title="@string/preference_interface"
+        android:key="@string/preference_interface">
+        <intent
+            android:targetPackage="@string/application_package"
+            android:targetClass="com.xabber.android.ui.preferences.ThemeSettings"/>
+    </Preference>
+    <Preference
         android:key="@string/preference_contacts"
         android:title="@string/preference_contacts">
         <intent

--- a/app/src/main/res/xml/preference_theme.xml
+++ b/app/src/main/res/xml/preference_theme.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+        <ListPreference
+            android:title="@string/interface_theme"
+            android:key="@string/interface_theme_key"
+            android:entries="@array/interface_theme_entries"
+            android:entryValues="@array/interface_theme_entryvalues"
+            android:defaultValue="@string/interface_theme_default"
+            />
+</PreferenceScreen>


### PR DESCRIPTION
The problem with the last commit, is that when changing the theme, then clicking on a contact, Xabber crashes.

Actually adding the dark theme, made me discover an issue in the menu (probably related to https://github.com/redsolution/xabber-android/issues/372), is that the menu theme is light even if I use the dark theme.