### PR TITLE
Added preference constraints to number fields

### DIFF
--- a/app/src/main/res/xml/account_editor_oauth.xml
+++ b/app/src/main/res/xml/account_editor_oauth.xml
@@ -53,6 +53,7 @@
     <EditTextPreference
         android:key="@string/account_proxy_port_key"
         android:title="@string/account_proxy_port"
+        android:inputType="number"
         android:singleLine="true"
         />
     <EditTextPreference

--- a/app/src/main/res/xml/account_editor_xmpp.xml
+++ b/app/src/main/res/xml/account_editor_xmpp.xml
@@ -60,6 +60,7 @@
         android:key="@string/account_port_key"
         android:title="@string/account_port"
         android:singleLine="true"
+        android:inputType="number"
         android:dependency="@string/account_custom_key"
         />
     <EditTextPreference
@@ -102,6 +103,7 @@
     <EditTextPreference
         android:key="@string/account_proxy_port_key"
         android:title="@string/account_proxy_port"
+        android:inputType="number"
         android:singleLine="true"
         />
     <EditTextPreference

--- a/app/src/main/res/xml/account_editor_xmpp.xml
+++ b/app/src/main/res/xml/account_editor_xmpp.xml
@@ -71,6 +71,7 @@
     <com.xabber.android.ui.widget.PriorityPreference
         android:key="@string/account_priority_key"
         android:title="@string/account_priority"
+        android:inputType="numberSigned"
         android:singleLine="true"
         />
     <CheckBoxPreference

--- a/app/src/main/res/xml/preference_editor.xml
+++ b/app/src/main/res/xml/preference_editor.xml
@@ -268,6 +268,7 @@
                     android:defaultValue="@string/connection_priority_chat_default"
                     android:dependency="@string/connection_adjust_priority_key"
                     android:title="@string/chat"
+                    android:inputType="numberSigned"
                     android:singleLine="true"
                     />
                 <com.xabber.android.ui.widget.PriorityPreference
@@ -275,6 +276,7 @@
                     android:defaultValue="@string/connection_priority_available_default"
                     android:dependency="@string/connection_adjust_priority_key"
                     android:title="@string/available"
+                    android:inputType="numberSigned"
                     android:singleLine="true"
                     />
                 <com.xabber.android.ui.widget.PriorityPreference
@@ -282,6 +284,7 @@
                     android:defaultValue="@string/connection_priority_away_default"
                     android:dependency="@string/connection_adjust_priority_key"
                     android:title="@string/away"
+                    android:inputType="numberSigned"
                     android:singleLine="true"
                     />
                 <com.xabber.android.ui.widget.PriorityPreference
@@ -289,6 +292,7 @@
                     android:defaultValue="@string/connection_priority_xa_default"
                     android:dependency="@string/connection_adjust_priority_key"
                     android:title="@string/xa"
+                    android:inputType="numberSigned"
                     android:singleLine="true"
                     />
                 <com.xabber.android.ui.widget.PriorityPreference
@@ -296,6 +300,7 @@
                     android:defaultValue="@string/connection_priority_dnd_default"
                     android:dependency="@string/connection_adjust_priority_key"
                     android:title="@string/dnd"
+                    android:inputType="numberSigned"
                     android:singleLine="true"
                     />
             </PreferenceCategory>


### PR DESCRIPTION
The fields that are supposed to have numbers now have the proper attributes to bring up the virtual keypad instead of the full keyboard. This helps beginners from messing up the configuration and also is more convenient to all.