### PR TITLE
Revert change that causes Xabber to crash when text selected (Fix: #384)

### DIFF
--- a/app/src/main/res/drawable/myapp_action_mode_background.xml
+++ b/app/src/main/res/drawable/myapp_action_mode_background.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:top="-2dp" android:left="-2dp" android:right="-2dp">
         <shape android:shape="rectangle">
-            <solid android:color="?attr/colorPrimary"/>
+            <solid android:color="@color/primary_material_dark"/>
         </shape>
     </item>
 </layer-list>


### PR DESCRIPTION
Note: this does not affect the red color of the action bar unless when
text is selected.