### PR TITLE
Revert "Correctly use SRV specified hostname for cert validation (#204)"

### DIFF
--- a/app/src/main/java/org/jivesoftware/smack/XMPPConnection.java
+++ b/app/src/main/java/org/jivesoftware/smack/XMPPConnection.java
@@ -848,7 +848,7 @@ public class XMPPConnection extends Connection {
                 throw new IllegalStateException();
             context.init(kms, new TrustManager[]{new XMPPTrustManager(
                     KeyStoreManager.getOrCreateKeyStore(config),
-                    getHost(), config.getCertificateListener(),
+                    getServiceName(), config.getCertificateListener(),
                     chainCheck, domainCheck, allowSelfSigned)}, SECURE_RANDOM);
         }
         Socket plain = socket;


### PR DESCRIPTION
Reverts redsolution/xabber-android#451

The RFC says certificates should be checked with servicename and not resolved srv hostnames.
Please revert merijn's patch. It breaks connections to servers which obey the standard. 

For example: https://github.com/redsolution/xabber-android/issues/454