### PR TITLE
Add message carbons to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Supported protocols
 * XEP-0136: Message Archiving
 * XEP-0224: Attention
 * XEP-0077: In-Band Registration
+* XEP-0280: Message Carbons
 
 Translations
 ============


### PR DESCRIPTION
Message Carbons where added to 1.0.3 according to the changelog:

https://github.com/redsolution/xabber-android/wiki/Xabber-Version-History#103-release-date-2015-05-12