### PR TITLE
feat(MUC): Add Preference to Suppress XEP Status Code 100

### DIFF
--- a/app/src/main/java/com/xabber/android/data/DatabaseManager.java
+++ b/app/src/main/java/com/xabber/android/data/DatabaseManager.java
@@ -38,7 +38,7 @@ public class DatabaseManager extends SQLiteOpenHelper implements
         OnLoadListener, OnClearListener {
 
     private static final String DATABASE_NAME = "xabber.db";
-    private static final int DATABASE_VERSION = 67;
+    private static final int DATABASE_VERSION = 68;
 
     private static final SQLiteException DOWNGRAD_EXCEPTION = new SQLiteException(
             "Database file was deleted");

--- a/app/src/main/java/com/xabber/android/data/SettingsManager.java
+++ b/app/src/main/java/com/xabber/android/data/SettingsManager.java
@@ -227,6 +227,11 @@ public class SettingsManager implements OnInitializedListener,
                 R.bool.events_vibro_default);
     }
 
+    public static boolean eventsSuppress100() {
+        return getBoolean(R.string.chat_events_suppress_100_key,
+                R.bool.chat_events_suppress_100_default);
+    }
+
     public static boolean eventsIgnoreSystemVibro() {
         return getBoolean(R.string.events_ignore_system_vibro_key,
                 R.bool.events_ignore_system_vibro_default);

--- a/app/src/main/java/com/xabber/android/data/extension/muc/RoomChat.java
+++ b/app/src/main/java/com/xabber/android/data/extension/muc/RoomChat.java
@@ -22,6 +22,7 @@ import com.xabber.android.data.account.StatusMode;
 import com.xabber.android.data.message.AbstractChat;
 import com.xabber.android.data.message.ChatAction;
 import com.xabber.android.data.message.MessageItem;
+import com.xabber.android.data.message.chat.ChatManager;
 import com.xabber.android.data.roster.RosterManager;
 import com.xabber.xmpp.address.Jid;
 import com.xabber.xmpp.delay.Delay;
@@ -198,6 +199,11 @@ public class RoomChat extends AbstractChat {
             if (mucUser != null && mucUser.getDecline() != null) {
                 onInvitationDeclined(mucUser.getDecline().getFrom(), mucUser.getDecline().getReason());
                 return true;
+            }
+            if (mucUser != null && mucUser.getStatus() != null && mucUser.getStatus().getCode().equals("100")
+                    && ChatManager.getInstance().isSuppress100(account, user)) {
+                    // 'This room is not anonymous'
+                    return true;
             }
             final String text = message.getBody();
             final String subject = message.getSubject();

--- a/app/src/main/java/com/xabber/android/data/message/chat/Suppress100Table.java
+++ b/app/src/main/java/com/xabber/android/data/message/chat/Suppress100Table.java
@@ -1,0 +1,62 @@
+package com.xabber.android.data.message.chat;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import com.xabber.android.data.DatabaseManager;
+
+/**
+ * Storage with suppress100 settings for each chat.
+ * @author <a href="mailto:jaro.fietz@uniscon.de">Jaro Fietz</a>.
+ */
+class Suppress100Table extends AbstractChatPropertyTable<Boolean> {
+
+    static final String NAME = "chat_suppress_100";
+
+    private final static Suppress100Table instance;
+
+    static {
+        instance = new Suppress100Table(DatabaseManager.getInstance());
+        DatabaseManager.getInstance().addTable(instance);
+    }
+
+    public static Suppress100Table getInstance() {
+        return instance;
+    }
+
+    private Suppress100Table(DatabaseManager databaseManager) {
+        super(databaseManager);
+    }
+
+    @Override
+    protected String getTableName() {
+        return NAME;
+    }
+
+    @Override
+    String getValueType() {
+        return "INTEGER";
+    }
+
+    @Override
+    void bindValue(SQLiteStatement writeStatement, Boolean value) {
+        writeStatement.bindLong(3, value ? 1 : 0);
+    }
+
+    @Override
+    public void migrate(SQLiteDatabase db, int toVersion) {
+        super.migrate(db, toVersion);
+        switch (toVersion) {
+            case 68:
+                initialMigrate(db, NAME, "INTEGER");
+                break;
+            default:
+                break;
+        }
+    }
+
+    static boolean getValue(Cursor cursor) {
+        return cursor.getLong(cursor.getColumnIndex(Fields.VALUE)) != 0;
+    }
+
+}

--- a/app/src/main/java/com/xabber/android/ui/preferences/ChatContactSettingsFragment.java
+++ b/app/src/main/java/com/xabber/android/ui/preferences/ChatContactSettingsFragment.java
@@ -53,6 +53,8 @@ public class ChatContactSettingsFragment extends BaseSettingsFragment {
                 .isMakeVibro(account, user));
         putValue(map, R.string.chat_events_sound_key, ChatManager.getInstance()
                 .getSound(account, user));
+        putValue(map, R.string.chat_events_suppress_100_key, ChatManager.getInstance()
+                .isSuppress100(account, user));
         return map;
     }
 
@@ -82,6 +84,9 @@ public class ChatContactSettingsFragment extends BaseSettingsFragment {
             ChatManager.getInstance().setSound(account, user,
                     getUri(result, R.string.chat_events_sound_key));
 
+        if (hasChanges(source, result, R.string.chat_events_suppress_100_key))
+            ChatManager.getInstance().setSuppress100(account, user,
+                    getBoolean(result, R.string.chat_events_suppress_100_key));
         return true;
     }
 

--- a/app/src/main/res/values-de-rDE/preference_editor.xml
+++ b/app/src/main/res/values-de-rDE/preference_editor.xml
@@ -65,6 +65,7 @@
   <string name="events_message_none">Nicht benachrichtigen</string>
   <string name="events_show_text">Nachricht in der Statusleiste anzeigen\nNachricht in der Statusleiste anzeigen</string>
   <string name="events_visible_chat">Benachrichtigung bei offenem Chat\nBenachrichtigung bei eingehender Nachricht im offenen Chat</string>
+  <string name="events_suppress_100">Unterdrücke Status Code 100\nUnterdrücke \'Dieser Raum ist nicht anonym\' Meldungen</string>
   <string name="negative_priotiry_summary">%s (Du wirst aus keinem Chat Nachrichten erhalten)</string>
   <string name="preference_accounts">XMPP-Konten\nKonten verwalten</string>
   <string name="preference_security">Sicherheit\nSicherheitseinstellungen</string>

--- a/app/src/main/res/values/preference_editor.xml
+++ b/app/src/main/res/values/preference_editor.xml
@@ -64,6 +64,7 @@
     <string name="events_message_none">Don\'t notify</string>
     <string name="events_show_text">Show message in notification\nShow message text in notification area</string>
     <string name="events_visible_chat">Notify in current chat\nNotify on incoming messages in current chat</string>
+    <string name="events_suppress_100">Suppress Status Code 100\nDon\'t get \'This room is not anonymous\' messages</string>
     <string name="negative_priotiry_summary">%s (you won\'t receive messages from any chat)</string>
     <string name="preference_accounts">XMPP accounts\nManage accounts</string>
     <string name="preference_security">Security\nSecurity settings</string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -74,6 +74,7 @@
         <item>com.xabber.android.data.extension.otr.OTRTable</item>
         <item>com.xabber.android.data.message.chat.VibroTable</item>
         <item>com.xabber.android.data.notification.NotificationTable</item>
+        <item>com.xabber.android.data.message.chat.Suppress100Table</item>
         <item>com.xabber.android.data.message.phrase.PhraseTable</item>
     </string-array>
 
@@ -494,6 +495,9 @@
 
     <string name="chat_events_vibro_key">chat_events_vibro</string>
     <string name="chat_events_visible_chat_key">chat_events_visible_chat</string>
+
+    <string name="chat_events_suppress_100_key">chat_events_suppress_100</string>
+    <bool name="chat_events_suppress_100_default">false</bool>
 
 <!-- preference_xabber -->
     <string name="preference_xabber_key">preference_xabber</string>

--- a/app/src/main/res/xml/preference_chat_contact.xml
+++ b/app/src/main/res/xml/preference_chat_contact.xml
@@ -40,4 +40,8 @@
         android:key="@string/chat_events_visible_chat_key"
         android:title="@string/events_visible_chat"
         />
+    <CheckBoxPreference
+            android:key="@string/chat_events_suppress_100_key"
+            android:title="@string/events_suppress_100"
+            />
 </PreferenceScreen>


### PR DESCRIPTION
XEP Status Code 100 tells the XMPP client application, that a room is not
anonymous, which means that JIDs of all members are revealed.

Unfortunately, XEP states, that the Server should send an body together
with the status code, containing 'This room is not anonymous'.

Extract from XEP 1.24:
```
Example 24. Service Warns New Occupant About Lack of Anonymity

<message
    from='darkcave@chat.shakespeare.lit'
    to='hag66@shakespeare.lit/pda'
    type='groupchat'>
  <body>This room is not anonymous.</body>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <status code='100'/>
  </x>
</message>
```
Therefore each time a user enters a non-anonymous room he receives a
message containing "This room is not anonymous".
A problem with this is the fact, that this happens with every reconnect
of the mobile connection. For each room with every internet change (WiFi
to mobile or vice versa, or just unstable internet) one'll get a
notificaton.

To stop this from happening I added an Option to the Chat-Room-Settings,
which allows to suppress this messages. This way users can suppress them
for the rooms they don't need this notificaton.