### PR TITLE
Enable XEP-0198 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Supported protocols
 * XEP-0224: Attention
 * XEP-0077: In-Band Registration
 * XEP-0352: Client State Indication
+* XEP-0198: Stream Management
 
 Translations
 ============

--- a/README.rst
+++ b/README.rst
@@ -23,26 +23,26 @@ Supported protocols
 * RFC-3920: Core
 * RFC-3921: Instant Messaging and Presence
 * XEP-0030: Service Discovery
-* XEP-0128: Service Discovery Extensions
-* XEP-0115: Entity Capabilities
-* XEP-0054: vcard-temp
-* XEP-0153: vCard-Based Avatars
 * XEP-0045: Multi-User Chat (incompletely)
-* XEP-0078: Non-SASL Authentication
-* XEP-0138: Stream Compression
-* XEP-0203: Delayed Delivery
-* XEP-0091: Legacy Delayed Delivery
-* XEP-0199: XMPP Ping
-* XEP-0147: XMPP URI Scheme Query Components
-* XEP-0085: Chat State Notifications
-* XEP-0184: Message Delivery Receipts
-* XEP-0155: Stanza Session Negotiation
+* XEP-0054: vcard-temp
 * XEP-0059: Result Set Management
-* XEP-0136: Message Archiving
-* XEP-0224: Attention
 * XEP-0077: In-Band Registration
-* XEP-0352: Client State Indication
+* XEP-0078: Non-SASL Authentication
+* XEP-0085: Chat State Notifications
+* XEP-0091: Legacy Delayed Delivery
+* XEP-0115: Entity Capabilities
+* XEP-0128: Service Discovery Extensions
+* XEP-0136: Message Archiving
+* XEP-0138: Stream Compression
+* XEP-0147: XMPP URI Scheme Query Components
+* XEP-0153: vCard-Based Avatars
+* XEP-0155: Stanza Session Negotiation
+* XEP-0184: Message Delivery Receipts
 * XEP-0198: Stream Management
+* XEP-0199: XMPP Ping
+* XEP-0203: Delayed Delivery
+* XEP-0224: Attention
+* XEP-0352: Client State Indication
 
 Translations
 ============

--- a/xabber/src/main/java/com/xabber/android/data/connection/ConnectionThread.java
+++ b/xabber/src/main/java/com/xabber/android/data/connection/ConnectionThread.java
@@ -86,7 +86,7 @@ public class ConnectionThread implements
     /**
      * SMACK connection.
      */
-    private AbstractXMPPConnection xmppConnection;
+    private XMPPTCPConnection xmppConnection;
 
     /**
      * Thread holder for this connection.
@@ -212,6 +212,10 @@ public class ConnectionThread implements
         xmppConnection = new XMPPTCPConnection(builder.build());
         xmppConnection.addAsyncStanzaListener(this, ACCEPT_ALL);
         xmppConnection.addConnectionListener(this);
+
+        // enable Stream Management support. SMACK will only enable SM if supported by the server,
+        // so no additional checks are required.
+        xmppConnection.setUseStreamManagement(true);
 
         // by default Smack disconnects in case of parsing errors
         xmppConnection.setParsingExceptionCallback(new ExceptionLoggingCallback());


### PR DESCRIPTION
Support for stream management was added in Smack 4.1.0, so toggling the pref is enough. We don't need to check the server capabilities ourselves, quoting the [Smack documentation](https://www.igniterealtime.org/builds/smack/docs/latest/javadoc/org/jivesoftware/smack/tcp/XMPPTCPConnection.html#setUseStreamManagement%28boolean%29):

> Set if Stream Management should be used **if supported by the server**.

I also removed the unnecessary cast from `AbstractXMPPConnection` to `XMPPTCPConnection` because we actually do have a `XMPPTCPConnection` here and I see no reason to cast here. Feel free to prove me wrong.

In my second commit, I have sorted the list of supported XEPs which is not really in the scope of this PR. I usually don't like sidetracked changes like this, but I think it really improves readability... Feel free to complain, I'll happily remove this commit if needed.

Merging this would resolve #67.