### PR TITLE
Build failure: some dummy App Id is required in google-services.json

### DIFF
--- a/xabber/src/dev/google-services.json
+++ b/xabber/src/dev/google-services.json
@@ -1,12 +1,12 @@
 {
   "project_info": {
     "project_number": "",
-    "project_id": ""
+    "project_id": "this-is-a-sample"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "",
+        "mobilesdk_app_id": "1:999999999999:android:0000000000000000",
         "android_client_info": {
           "package_name": "com.xabber.android.beta"
         }
@@ -53,7 +53,7 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "",
+        "mobilesdk_app_id": "1:999999999999:android:0000000000000000",
         "android_client_info": {
           "package_name": "com.xabber.android"
         }
@@ -92,7 +92,7 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "",
+        "mobilesdk_app_id": "1:999999999999:android:0000000000000000",
         "android_client_info": {
           "package_name": "com.xabber.androidvip"
         }
@@ -131,7 +131,7 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "",
+        "mobilesdk_app_id": "1:999999999999:android:0000000000000000",
         "android_client_info": {
           "package_name": "com.xabber.androiddev"
         }


### PR DESCRIPTION
I was building with
`./gradlew -Pbuild=dev assembleDevDebug`

which failed with:
`Execution failed for task ':xabber:processDevDebugGoogleServices'. `
`> Missing Google App Id. Please follow instructions on https://firebase.google.com/ to get a valid config file that contains a Google App Id`

(The example app id is taken from https://github.com/googleads/googleads-mobile-android-examples/blob/master/admob/InterstitialExample/app/google-services.json)