### PR TITLE
Android 8+ file upload not working fix

### DIFF
--- a/xabber/src/main/AndroidManifest.xml
+++ b/xabber/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/application_title_full"
         android:theme="@style/Theme"
+        android:usesCleartextTraffic="true"
         tools:replace="label, icon, allowBackup"
         android:requestLegacyExternalStorage="true"
         android:hardwareAccelerated="true">


### PR DESCRIPTION
this change makes android 8+ clients work fine with http upload, as sometimes the server will not use https.